### PR TITLE
fix date serialization for restful calls

### DIFF
--- a/src/restful.ts
+++ b/src/restful.ts
@@ -18,7 +18,9 @@ export function mk_query(params: Object) : string {
             qs += '&'
 
         if( value != null ) {
-            if( typeof value != 'string' )
+            if( value instanceof Date)
+                value = value.toISOString()
+            else if( typeof value != 'string' )
                 value = JSON.stringify( value )
 
             qs += `${encodeURIComponent(key)}=${encodeURIComponent(value)}`


### PR DESCRIPTION
The serialization for restful query string is quite primitive (but sufficient),
if string we just pass it through, otherwise we use JSON serialization. However,
for Date this does not work out, which this commit fixes.